### PR TITLE
オリジナルのheaderのauthをAccess-Control-Allow-Headersに追加する

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -25,7 +25,7 @@ async function main() {
       res.header('Access-Control-Allow-Origin', '*');
       res.header(
         'Access-Control-Allow-Headers',
-        'Origin, X-Requested-With, Content-Type, Accept'
+        'Origin, X-Requested-With, Content-Type, Accept, auth'
       );
       res.header(
         'Access-Control-Allow-Methods',


### PR DESCRIPTION
https://github.com/m-miyauchi/api-sample-blog#api%E3%82%A8%E3%83%B3%E3%83%89%E3%83%9D%E3%82%A4%E3%83%B3%E3%83%88%E3%81%AE%E8%AA%8D%E8%A8%BC%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6
READMEに指定されている`'auth'`ヘッダーを許可する